### PR TITLE
Fix: drop dynamic field to support links in components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # strapi-plugin-lexical
 
-> Integrates the [Lexical WYSIWYG editor](https://lexical.dev/) as a custom field in Strapi.
+> Integrates the [Lexical WYSIWYG editor](https://lexical.dev/) as a custom field in Strapi. Basically a port of [Lexical playground](https://playground.lexical.dev/) into strapi environment with some nice extras.
 
 ![screenshot-lexical](https://github.com/user-attachments/assets/e861401d-c850-404f-a5c0-9c6bee0a8456)
 
@@ -20,11 +20,12 @@
   - [Usage](#usage)
     - [Handling Media and Internal Links](#handling-media-and-internal-links)
       - [Opt-in Mechanism](#opt-in-mechanism)
-        - [Example Fields](#example-fields)
-      - [Integration in Lexical](#integration-in-lexical)
+      - [Integration in Lexical documents](#integration-in-lexical-documents)
         - [Media References](#media-references)
         - [Internal Links](#internal-links)
-      - [Querying Related Data](#querying-related-data)
+      - [Rendering Strapi media and links](#rendering-strapi-media-and-links)
+        - [Fetch while rendering](#fetch-while-rendering)
+        - [Prefetch and inject for rendering](#prefetch-and-inject-for-rendering)
   - [Roadmap](#roadmap)
     - [v0 - Alpha](#v0---alpha)
     - [v1 - Stable](#v1---stable)
@@ -74,27 +75,25 @@
 
 ## Usage
 
-- A new **Lexical** field type will be available in the Strapi content-type builder.
+- A new **Lexical** custom field type will be available in the Strapi content-type builder.
 - Currently, it supports features migrated from the [Lexical playground](https://playground.lexical.dev/).
 - For rendering content on your frontend, consider using libraries like [payload-lexical-react-renderer](https://github.com/atelierdisko/payload-lexical-react-renderer) or similar tools.
 
 ### Handling Media and Internal Links
 
-This plugin ensures reliable rendering of images and internal links by maintaining relationships between rich text content and referenced entities. By using **dynamic zones** and **predefined components**, the full power of the Strapi API is available when querying related data.
+This plugin ensures reliable rendering of images and internal links by maintaining relationships between rich text content and referenced entities. By using a regular media field and **automatically generated or your own link components** we can ensure that all referenced media and internal links are readily available for your frontend, always reflecting the latest data.
 
 > **Important:** This is readme section is WIP. We will update this soon and give better examples on how to query and render images and links
 
 #### Opt-in Mechanism  
 
-To enable this feature, create a **secondary field** with the suffix **`Links`**. This field must be a **dynamic zone** where you define the types of content (media and collections) that should be linked.  
+To enable this feature, you have to create **secondary fields**:
+* With the suffix **`Media`** (e.G. `YourFieldNameMedia`): This field must be a multiple media field with editing disabled.
+* With the suffix **`Links`** (e.G. `YourFieldNameLinks`): This must be a component, either use our pregenerated `Links` component or build your own. Important: It should only contain relation fields and the field name must match the linked collection name.
 
-##### Example Fields  
-- **`Content`** (Type: Lexical Custom Field) – Stores the rich text content.  
-- **`ContentLinks`** (Type: Dynamic Zone) – Stores extracted references, with selected components for linking media and collections.  
+#### Integration in Lexical documents
 
-#### Integration in Lexical  
-
-Rich text content within Strapi is stored as **Lexical nodes**, which are automatically parsed and extracted into Strapi. This ensures that all referenced media and internal links are readily available for your frontend, always reflecting the latest data.
+Media is stored as a custom Lexical nodes, while store relations to strapi content with a custom URL format for links. These are automatically parsed and extracted into the fields you created above.
 
 ##### Media References
 
@@ -114,19 +113,40 @@ Rich text content within Strapi is stored as **Lexical nodes**, which are automa
   
   This ensures that even if a page’s slug changes, links remain valid.
 
-**Example: Fetching the Latest API Data**
+#### Rendering Strapi media and links
+
+There are two options:
+
+##### Fetch while rendering
+
+@todo
+
+Benefit: Less code, multiple API calls while rendering
+
+* adjust the rendering functions of each lexical node
+* actually.. can it even be asnyc? double check... this is the `not recommended way` anyways...
+
+**Example: Fetching the Latest API Data for a link**
 ```js
 const [collectionName, documentId] = linkNode.url.replace("strapi://", "").split("/");
 const articles = client.collection(collectionName);
 const singleArticle = await articles.findOne(documentId);
+// your link generation logic here ...
+return `/${singleArticle.locale}/blog/${singleArticle.slug}`
 ```
 
-#### Querying Related Data
+##### Prefetch and inject for rendering
 
-On the data side, the `yourFieldLinks` field can be queried as a **regular dynamic zone**, ensuring that referenced media and links are always up-to-date. This prevents broken images and outdated links while giving users better control over content dependencies.
+@todo
 
-By maintaining these relationships, users can be notified when deleting content that is still referenced elsewhere, helping prevent accidental data loss.
+To render media and links, we have to query the data from our media field and fields within the link component, then inject the data into our rendering process.
 
+Benefit: only one API call, more control
+
+* fetch fields
+* iterate through the lexical document
+* inject the document from the strapi api response into the lexical node for later rendering
+* the data is now available when rendering the lexical node in your renderer
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -97,17 +97,18 @@ Media is stored as a custom Lexical nodes, while store relations to strapi conte
 
 ##### Media References
 
-- Images are stored as **`StrapiImage`** node in Lexical.
+- Images are stored as **`strapi-image`** node in Lexical.
 - Other file types are planned but not yet supported.
+- The structure is rather simple, as you can see:
 
-**StrapiImage Node Data Structure:**
+**strapi-image Lexical Node Data Structure:**
 ```json
 { "documentId": "id_of_media_asset" }
 ```
 
 ##### Internal Links
 
-- Internal links are stored using the regular **`Link`** node in Lexical.
+- Internal links are stored using the regular **`link`** node in Lexical.
 - The URL follows the format:  
   `strapi://collectionName/documentId`
   

--- a/admin/src/components/Input.tsx
+++ b/admin/src/components/Input.tsx
@@ -57,7 +57,7 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
       });
 
       // Parse lexical document for images and links
-      const mediaNodes = ['strapiImage'];
+      const mediaNodes = ['strapi-image'];
       const linkNodes = ['link'];
 
       const mediaDocumentsIds: Set<string> = new Set();

--- a/admin/src/components/Input.tsx
+++ b/admin/src/components/Input.tsx
@@ -92,6 +92,10 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
                   $in: [...mediaDocumentsIds.values()],
                 },
               },
+              pagination: {
+                page: 1,
+                pageSize: mediaDocumentsIds.size,
+              },
             },
           });
 
@@ -120,6 +124,10 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
                   documentId: {
                     $in: [...documentIds.values()],
                   },
+                },
+                pagination: {
+                  page: 1,
+                  pageSize: documentIds.size,
                 },
               },
             }

--- a/admin/src/components/Input.tsx
+++ b/admin/src/components/Input.tsx
@@ -16,7 +16,6 @@ import PlaygroundEditorTheme from '../lexical/themes/PlaygroundEditorTheme';
 
 import Nodes from '../lexical/nodes';
 
-import { createGlobalStyle } from 'styled-components';
 import { InputProps } from '@strapi/strapi/admin';
 import { SerializedStrapiImageNode } from 'src/lexical/nodes/StrapiImageNode';
 import { SerializedLinkNode } from '@lexical/link';
@@ -31,6 +30,13 @@ interface CustomFieldsComponentProps {
   onChange: (event: { target: { name: string; value: unknown; type: string } }) => void;
   value: SerializedEditorState<SerializedLexicalNode>;
   error: MessageDescriptor;
+}
+interface Relation {
+  apiData: any;
+  label: string;
+  id: number;
+  status: string;
+  href: string;
 }
 
 const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & InputProps>(
@@ -50,6 +56,7 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
         target: { name, type: attribute.type, value: newValue },
       });
 
+      // Parse lexical document for images and links
       const mediaNodes = ['strapiImage'];
       const linkNodes = ['link'];
 
@@ -80,9 +87,7 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
 
       gatherStrapiRelations(newValue.root.children as SerializedElementNode[]);
 
-      const dynamicZoneValue = [];
-      let keyCounter = 0;
-
+      // Reference media
       if (mediaDocumentsIds.size > 0) {
         try {
           const resultFetchClient = await get(`/upload/files`, {
@@ -98,22 +103,32 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
               },
             },
           });
-
-          dynamicZoneValue.push({
-            __component: 'lexical-links.media',
-            __temp_key__: `l${keyCounter}`,
-            links: resultFetchClient.data.results,
+          onChange({
+            target: {
+              name: `${name}Media`,
+              type: 'media',
+              value: resultFetchClient.data.results,
+            },
           });
-          keyCounter++;
         } catch (err) {
           alert(
             'Failed to locate media used in the rich text. This may be due to a permission issue. Please contact your administrator or developer for assistance.'
           );
           console.error(err);
         }
+      } else {
+        onChange({
+          target: {
+            name: `${name}Media`,
+            type: 'media',
+            value: [],
+          },
+        });
       }
 
+      // Reference collections/links
       try {
+        const links: { [key: string]: { connect: Relation[] } } = {};
         for (const [collectionName, documentIds] of collectionLinks.entries()) {
           const resultIdentify = await get(`/lexical/identify/${collectionName}`);
           const resultFetchClient = await get(
@@ -133,39 +148,32 @@ const Input = React.forwardRef<HTMLDivElement, CustomFieldsComponentProps & Inpu
             }
           );
 
-          dynamicZoneValue.push({
-            __component: `lexical-links.${collectionName}`,
-            __temp_key__: `l${keyCounter}`,
-            links: {
-              connect: resultFetchClient.data.results.map(
-                (result: { id: number; documentId: string; [key: string]: unknown }) => ({
-                  apiData: result,
-                  label: result['name'] || result['title'] || result['label'] || result['headline'],
-                  id: result.id,
-                  status: result.status,
-                  href: `/content-manager/collection-types/${resultIdentify.data.collectionUID}/${result.documentId}`,
-                })
-              ),
-              // @todo we probably have to maintain disconnect array as well to avoid issues on long term. No time right now for that ;)
-            },
-          });
-          keyCounter++;
+          links[collectionName] = {
+            connect: resultFetchClient.data.results.map(
+              (result: { id: number; documentId: string; [key: string]: unknown }) => ({
+                apiData: result,
+                label: result['name'] || result['title'] || result['label'] || result['headline'],
+                id: result.id,
+                status: result.status,
+                href: `/content-manager/collection-types/${resultIdentify.data.collectionUID}/${result.documentId}`,
+              })
+            ),
+            // @todo we probably have to maintain disconnect array as well to avoid issues on long term. No time right now for that ;)
+          };
         }
+        onChange({
+          target: {
+            name: `${name}Links`,
+            type: 'component',
+            value: links,
+          },
+        });
       } catch (err) {
         alert(
           'Failed to locate linked collection entries in the rich text. This may be due to a permission issue. Please contact your administrator or developer for assistance.'
         );
         console.error(err);
       }
-
-      // Set value for dynamic zone field
-      onChange({
-        target: {
-          name: `${name}Links`,
-          type: 'dynamiczone',
-          value: dynamicZoneValue,
-        },
-      });
     };
 
     const handleChangeCb = React.useCallback(

--- a/admin/src/components/LinkModal.tsx
+++ b/admin/src/components/LinkModal.tsx
@@ -20,7 +20,7 @@ import {
   useFetchClient,
 } from '@strapi/strapi/admin';
 
-const highlightText = (text: string, q: string): JSX.Element => {
+const highlightText = (text: string, q: string): React.ReactElement => {
   if (!q.trim().length) return <>{text}</>;
 
   const regex = new RegExp(`(${q})`, 'gi');

--- a/admin/src/lexical/nodes/StrapiImageNode.tsx
+++ b/admin/src/lexical/nodes/StrapiImageNode.tsx
@@ -48,7 +48,7 @@ export class StrapiImageNode extends DecoratorNode<JSX.Element> {
   __src: string;
 
   static getType(): string {
-    return 'strapiImage';
+    return 'strapi-image';
   }
 
   static clone(node: StrapiImageNode): StrapiImageNode {

--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -1,85 +1,46 @@
 import type { Core, Struct } from '@strapi/strapi';
 
 const bootstrap = async ({ strapi }: { strapi: Core.Strapi }) => {
-  // Create media links component
-  const mediaComponentUID: `${string}.${string}` = `lexical-links.media`;
-  const mediaComponentSchema: Partial<Struct.ComponentSchema> = {
-    category: 'lexical-links',
-    // @ts-expect-error yes, its there, and required. types seem to be wrong
-    displayName: 'Media',
-    uid: mediaComponentUID,
-    info: {
-      displayName: 'Media',
-      description: `Component linking to media`,
-    },
-    attributes: {
-      links: {
-        type: 'media',
-        multiple: true,
-      },
-    },
-  };
-
-  const validComponents: string[] = [mediaComponentUID];
-  const existingComponents = Object.keys(strapi.components);
-
-  if (!existingComponents.includes(mediaComponentUID)) {
-    strapi.log.info(`Lexical: Creating links component for media assets: ${mediaComponentUID}`);
-    await strapi
-      .plugin('content-type-builder')
-      .services.components.createComponent({ component: mediaComponentSchema });
-  }
-
   // Retrieve all API content types (excluding core types like users-permissions)
   const contentTypes = Object.entries(strapi.contentTypes)
     .filter(([uid]) => uid.startsWith('api::')) // Only user-defined content types
     .map(([uid]) => uid);
 
+  const attributes: { [key: string]: { type: string; relation: string; target: string } } = {};
+
   for (const contentTypeUID of contentTypes) {
     const contentType = strapi.contentTypes[contentTypeUID];
 
     if (contentType) {
-      const cleanCollectionName = contentType.collectionName.replace(/_/g, ' ');
-      const componentUID: `${string}.${string}` = `lexical-links.${cleanCollectionName.replace(/ /g, '-')}`;
-      validComponents.push(componentUID);
-      const componentSchema: Struct.ComponentSchema = {
-        category: 'lexical-links',
-        displayName: cleanCollectionName,
-        uid: componentUID,
-        info: {
-          displayName: cleanCollectionName,
-          description: `Component linking to ${contentType.info.displayName}`,
-        },
-        attributes: {
-          links: {
-            type: 'relation',
-            relation: 'oneToMany',
-            // @ts-expect-error no we need an string here. wrong types?
-            target: contentTypeUID,
-            writable: false,
-          },
-        },
+      attributes[contentType.collectionName] = {
+        type: 'relation',
+        relation: 'oneToMany',
+        target: contentTypeUID,
       };
-
-      // Check if component already exists before creating it
-      if (!existingComponents.some((component) => component === componentUID)) {
-        strapi.log.info(`Lexical: Creating links component for ${componentUID}`);
-        // Register the component
-        await strapi
-          .plugin('content-type-builder')
-          .services.components.createComponent({ component: componentSchema });
-      }
     }
   }
 
-  // Delete links to old/deleted collections
-  for (const outdatedLinkComponent of existingComponents.filter(
-    (c) => c.startsWith('lexical-links.') && !validComponents.includes(c)
-  )) {
-    strapi.log.info(`Lexical: Deleting outdated links component of ${outdatedLinkComponent}`);
+  // Create default links component
+  const linksComponentUID: `${string}.${string}` = `links.links`;
+  const linksComponentSchema: Partial<Struct.ComponentSchema> = {
+    category: 'links',
+    // @ts-expect-error yes, its there, and required. types seem to be wrong
+    displayName: 'Links',
+    uid: linksComponentUID,
+    info: {
+      displayName: 'Links',
+      description: `Component linking to all collection types by default`,
+      icon: 'link',
+    },
+    attributes: attributes as any,
+  };
+
+  const existingComponents = Object.keys(strapi.components);
+  if (!existingComponents.includes(linksComponentUID)) {
+    strapi.log.info(`Lexical: Creating default links component: ${linksComponentUID}`);
     await strapi
       .plugin('content-type-builder')
-      .services.components.deleteComponent(outdatedLinkComponent);
+      .services.components.createComponent({ component: linksComponentSchema });
   }
 };
 


### PR DESCRIPTION
### **User description**
This simplifies our data structure and allows components to have lexical fields which relations to media and collections get auto populated based on the content within lexical.

Potentially breaking... so will be `v0.2.0`


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Refactored handling of media and links in Lexical editor.
  - Removed dynamic zones, introduced dedicated fields for media and links.
  - Enhanced parsing and extraction of media and links.

- Simplified backend logic for managing relations to collections and media.
  - Introduced a default `Links` component for all collections.
  - Removed outdated components and streamlined component creation.

- Updated README with detailed usage and integration instructions.
  - Added examples for media and link handling.
  - Clarified rendering strategies for media and links.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Input.tsx</strong><dd><code>Refactor media and link handling in Input component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/src/components/Input.tsx

<li>Refactored media and link handling logic.<br> <li> Removed dynamic zone usage for links.<br> <li> Added dedicated fields for media and links.<br> <li> Improved error handling and parsing of Lexical documents.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/2/files#diff-6c6b71312580a8b83c9be502cf22075934c071c91bf129a2ba5a393e4270db4f">+52/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LinkModal.tsx</strong><dd><code>Update type for highlightText function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/src/components/LinkModal.tsx

- Updated type for highlightText function.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/2/files#diff-2bb1ef5a1d033b28fea16932b72474748236eb86bbb265c5bbd96b63881f3cda">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bootstrap.ts</strong><dd><code>Simplify component management for media and links</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/bootstrap.ts

<li>Removed dynamic zone components for media and links.<br> <li> Introduced a default <code>Links</code> component for all collections.<br> <li> Streamlined component creation and deletion logic.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/2/files#diff-b9ebdb882e542af204b879db5e5e6f43a26f84aaf4bb62a4425cc41f5e1540cf">+25/-64</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lexical-search.ts</strong><dd><code>Refactor search logic for Lexical editor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/controllers/lexical-search.ts

<li>Refactored search logic to handle all collections.<br> <li> Removed dependency on dynamic zone components.<br> <li> Enhanced query handling for content types.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/2/files#diff-02914e2f488d0c382c68fd1dbaf18011d14cb5019aff1da67aa507eb2aaa4b42">+27/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with enhanced usage and integration details</code></dd></summary>
<hr>

README.md

<li>Updated usage instructions for media and link handling.<br> <li> Added examples for rendering strategies.<br> <li> Clarified integration details for Lexical documents.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+37/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>