### PR TITLE
fix: replace the current icon with a better one

### DIFF
--- a/admin/src/components/ icons/icon.types.ts
+++ b/admin/src/components/ icons/icon.types.ts
@@ -1,0 +1,4 @@
+export type IconProps = {
+  children?: never;
+  color?: string;
+} & React.SVGAttributes<SVGElement>;

--- a/admin/src/components/LexicalIcon.tsx
+++ b/admin/src/components/LexicalIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { IconProps } from './ icons/icon.types';
+
+export const LexicalIcon = React.forwardRef<SVGSVGElement, IconProps>(
+  ({ width = '30', height = '23', color = 'currentColor', className, ...props }, forwardedRef) => (
+    <svg
+      ref={forwardedRef}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 32 32"
+      width="16"
+      height="16"
+      className={className}
+      {...props}
+    >
+      <rect width={width} height={height} x=".5" y="4.5" fill="#EAF5FF" stroke="#B8E1FF" rx="2.5" />
+      <path fill="#76b6ff" d="M13.204 14.77H9.476V13.56h3.728z" />
+      <path d="M17.78 14.77h-3.728V13.56h3.728z" />
+      <path
+        fill="#76b6ff"
+        d="M20.153 14.77h-1.525V13.56h1.525zM15.577 16.709H9.476v-1.212h6.101zM20.153 16.709h-3.729v-1.212h3.73z"
+      />
+      <path d="M13.204 18.648H9.476v-1.212h3.728z" />
+      <path fill="#76b6ff" d="M17.78 18.648h-3.728v-1.212h3.728z" />
+      <path d="M20.153 18.648h-1.525v-1.212h1.525z" />
+      <path d="M24.56 9.318v1.211h-1.865v11.148h1.865v1.212h-5.254v-1.212H21V10.529h-1.695V9.318Zm-4.407 1.817v1.212H7.781v7.512h12.372v1.212H6.086v-9.936Zm5.932 0v9.936h-2.542V19.86h.847v-7.512h-.847v-1.212Z" />
+    </svg>
+  )
+);
+
+LexicalIcon.displayName = 'LexicalIcon';

--- a/admin/src/components/PluginIcon.tsx
+++ b/admin/src/components/PluginIcon.tsx
@@ -1,5 +1,0 @@
-import { Pencil } from '@strapi/icons';
-
-const PluginIcon = () => <Pencil />;
-
-export { PluginIcon };

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -1,7 +1,7 @@
-import { PLUGIN_ID } from './pluginId';
-import { Initializer } from './components/Initializer';
-import { PluginIcon } from './components/PluginIcon';
 import { StrapiApp } from '@strapi/strapi/admin';
+import { Initializer } from './components/Initializer';
+import { LexicalIcon } from './components/LexicalIcon';
+import { PLUGIN_ID } from './pluginId';
 
 export default {
   register(app: StrapiApp) {
@@ -24,7 +24,7 @@ export default {
         id: 'lexical.lexical.description',
         defaultMessage: 'Lexical advanced WYSIWYG editor',
       },
-      icon: PluginIcon,
+      icon: LexicalIcon,
       components: {
         Input: async () =>
           // @ts-expect-error its fine and works, the typing of the props seems to be wrong at the moment


### PR DESCRIPTION
### **User description**
It replaces the current icon with a beautier one:
![image](https://github.com/user-attachments/assets/c46dd1cd-084b-4001-9958-54398c893b54)


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new `LexicalIcon` component for improved icon design.

- Replaced the existing `PluginIcon` with `LexicalIcon` in the plugin registration.

- Introduced a new `IconProps` type for SVG icon properties.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>icon.types.ts</strong><dd><code>Introduced `IconProps` type for SVG icons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/src/components/icons/icon.types.ts

<li>Added a new <code>IconProps</code> type for SVG attributes.<br> <li> Defined optional <code>color</code> and <code>children</code> properties.


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LexicalIcon.tsx</strong><dd><code>Added new `LexicalIcon` component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/src/components/LexicalIcon.tsx

<li>Created a new <code>LexicalIcon</code> component using React.<br> <li> Implemented SVG rendering with customizable properties.<br> <li> Added <code>displayName</code> for the component.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/4/files#diff-fe05e7b1ee05bd0d901b341c59070b4b8105e777169f14405d5a7ceb05fb6ed5">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Updated plugin registration to use `LexicalIcon`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

admin/src/index.ts

<li>Replaced <code>PluginIcon</code> with <code>LexicalIcon</code> in plugin registration.<br> <li> Adjusted imports to include the new <code>LexicalIcon</code>.


</details>


  </td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/4/files#diff-7b8730c09b71735a8358f6102353f1d22b1fe91e3b20d6443b9d54069c939df1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Additional files</strong></td><td><table>
<tr>
  <td><strong>icon.types.ts</strong></td>
  <td><a href="https://github.com/hashbite/strapi-plugin-lexical/pull/4/files#diff-63619d15beb4d0d4bbcb804561e91651e51860a8b00ffb2bf8ad056fcbf96fb0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>